### PR TITLE
Add #add_insurance_charge to BuilderBase

### DIFF
--- a/lib/ups/builders/builder_base.rb
+++ b/lib/ups/builders/builder_base.rb
@@ -56,6 +56,14 @@ module UPS
         access_request << element_with_value('Password', password)
       end
 
+      # Adds an InsuranceCharges section to the XML document being built
+      #
+      # @param [String] value The MonetaryValue of the InsuranceCharge
+      # @return [void]
+      def add_insurance_charge(value)
+        shipment_root << insurance_charge(value)
+      end
+
       # Adds a Request section to the XML document being built
       #
       # @param [String] action The UPS API Action requested
@@ -204,6 +212,10 @@ module UPS
 
       def code_description(name, code, description)
         multi_valued(name, Code: code, Description: description)
+      end
+
+      def insurance_charge(value)
+        multi_valued('InsuranceCharges', MonetaryValue: value)
       end
 
       def multi_valued(name, params)

--- a/spec/ups/builders/rate_builder_spec.rb
+++ b/spec/ups/builders/rate_builder_spec.rb
@@ -11,6 +11,7 @@ class UPS::Builders::TestRateBuilder < Minitest::Test
       builder.add_ship_to ship_to
       builder.add_ship_from shipper
       builder.add_package package
+      builder.add_insurance_charge '5.00'
     end
   end
 

--- a/spec/ups/builders/ship_confirm_builder_spec.rb
+++ b/spec/ups/builders/ship_confirm_builder_spec.rb
@@ -14,6 +14,7 @@ class UPS::Builders::TestShipConfirmBuilder < Minitest::Test
       builder.add_label_specification 'gif', { height: '100', width: '100' }
       builder.add_description 'Los Pollo Hermanos'
       builder.add_reference_number reference_number
+      builder.add_insurance_charge '5.00'
     end
   end
 


### PR DESCRIPTION
- adds InsuranceCharges with MonetaryValue for both Rate and ShipmentConfirm requests (added to the `builder_base` class)