### PR TITLE
use response as variable in all examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ end
 ```ruby
 require 'ups-ruby'
 server = UPS::Connection.new(test_mode: true)
-ship_response = server.ship do |shipment_builder|
+response = server.ship do |shipment_builder|
   shipment_builder.add_access_request 'API_KEY', 'USERNAME', 'PASSWORD'
   shipment_builder.add_shipper company_name: 'Veeqo Limited',
     phone_number: '01792 123456',
@@ -110,7 +110,7 @@ response.tracking_number
 ```ruby
 require 'ups-ruby'
 server = UPS::Connection.new(test_mode: true)
-ship_response = server.ship do |shipment_builder|
+response = server.ship do |shipment_builder|
   shipment_builder.add_access_request 'API_KEY', 'USERNAME', 'PASSWORD'
   shipment_builder.add_shipper company_name: 'Veeqo Limited',
     phone_number: '01792 123456',


### PR DESCRIPTION
I thought it would be helpful to get have the `response` in the example match the "Then use..." below it for easy copy/pasting while testing instead of having `ship_response` and `response` mismatches.