### PR TITLE
Do not validate Ireland state for SoldTo

### DIFF
--- a/lib/ups/builders/address_builder.rb
+++ b/lib/ups/builders/address_builder.rb
@@ -34,15 +34,19 @@ module UPS
       # @return [void]
       def validate
         opts[:state] = case opts[:country].downcase
-                       when 'us'
-                         normalize_us_state(opts[:state])
-                       when 'ca'
-                         normalize_ca_state(opts[:state])
-                       when 'ie'
-                         UPS::Data.ie_state_matcher(opts[:state])
-                       else
-                         ''
-                       end
+        when 'us'
+          normalize_us_state(opts[:state])
+        when 'ca'
+          normalize_ca_state(opts[:state])
+        when 'ie'
+          if opts[:skip_ireland_state_validation]
+            '_' # UPS requires at least one character for Ireland
+          else
+            UPS::Data.ie_state_matcher(opts[:state])
+          end
+        else
+          ''
+        end
       end
 
       # Changes :state based on UPS requirements for US Addresses

--- a/lib/ups/builders/organisation_builder.rb
+++ b/lib/ups/builders/organisation_builder.rb
@@ -26,6 +26,7 @@ module UPS
       def initialize(name, opts = {})
         self.name = name
         self.opts = opts
+        self.opts[:skip_ireland_state_validation] = (name == 'SoldTo')
       end
 
       # Returns an XML representation of company_name

--- a/spec/ups/builders/address_builder_spec.rb
+++ b/spec/ups/builders/address_builder_spec.rb
@@ -93,5 +93,25 @@ describe UPS::Builders::AddressBuilder do
         proc { subject }.must_raise UPS::Exceptions::InvalidAttributeError
       end
     end
+
+    describe "when 'skip_ireland_state_validation' is passed" do
+      before { address_hash.merge!(skip_ireland_state_validation: true) }
+
+      describe "does not normalize the state field" do
+        subject { UPS::Builders::AddressBuilder.new address_hash }
+
+        it "changes the state to a single blank character" do
+          subject.opts[:state].must_equal '_'
+        end
+      end
+
+      describe "when passed a empty state" do
+        subject { UPS::Builders::AddressBuilder.new address_hash.merge({ state: '' }) }
+
+        it "does not throw an exception" do
+          subject.opts[:state].must_equal '_'
+        end
+      end
+    end
   end
 end

--- a/spec/ups/builders/organisation_builder_spec.rb
+++ b/spec/ups/builders/organisation_builder_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe UPS::Builders::OrganisationBuilder do
+  subject { UPS::Builders::OrganisationBuilder.new(builder_name) }
+
+  describe "when the name is 'SoldTo'" do
+    let(:builder_name) { 'SoldTo' }
+
+    it "enables option to skip Ireland state validation" do
+      subject.opts[:skip_ireland_state_validation].must_equal true
+    end
+  end
+
+  describe "when the name is anything else" do
+    let(:builder_name) { 'Hamburger' }
+
+    it "disables option to skip Ireland state validation" do
+      subject.opts[:skip_ireland_state_validation].must_equal false
+    end
+  end
+end


### PR DESCRIPTION
The `state` field should not be provided for SoldTo for some countries. Otherwise UPS returns this error:

`Invalid sold to state province code. Valid length is 0 to 5 alphanumeric`

To avoid the error, the user can simply not provide this field, but if the country is Ireland then a validator raises an error if it is not a valid Ireland county. This PR will skip this Ireland validation for SoldTo and send a blank character instead.