### PR TITLE
Fix NoMethodError on building requests without some options

### DIFF
--- a/lib/ups/builders/organisation_builder.rb
+++ b/lib/ups/builders/organisation_builder.rb
@@ -71,9 +71,9 @@ module UPS
       # @return [Ox::Element] XML representation of the current object
       def to_xml
         Element.new(name).tap do |org|
-          org << company_name
-          org << phone_number
-          org << attention_name
+          org << company_name if opts[:company_name]
+          org << phone_number if opts[:phone_number]
+          org << attention_name if opts[:attention_name]
           org << address
           org << tax_identification_number
         end


### PR DESCRIPTION
Fixes https://github.com/veeqo/ups-ruby/issues/18.

As for now, [the example in Readme](https://github.com/veeqo/ups-ruby#return-rates) doesn't contain `attention_name` and it throws exceptions. 
This fix could help for other developers to start using this library.

