### PR TITLE
Fix error_description on successful response

### DIFF
--- a/lib/ups/parsers/base_parser.rb
+++ b/lib/ups/parsers/base_parser.rb
@@ -37,6 +37,7 @@ module UPS
       end
 
       def build_error_description(errors_node)
+        return unless errors_node
         return errors_node.last[:ErrorDescription] if errors_node.is_a?(Array)
 
         errors_node[:ErrorDescription]


### PR DESCRIPTION
When request returns with a successful status, response doesn't contain Error element.
As a result, `error_description` throws an exception. It's confusing.

**Steps to reproduce**
```ruby
require 'ups'
server = UPS::Connection.new(test_mode: true)
response = server.rates do |rate_builder|
  rate_builder.add_access_request 'API_KEY', 'USERNAME', 'PASSWORD'
  rate_builder.add_shipper company_name: 'Veeqo Limited', phone_number: '01792 123456', attention_name: 'Veeqo', address_line_1: '11 Wind Street', city: 'Swansea', state: 'Wales', postal_code: 'SA1 1DA', country: 'GB', shipper_number: 'ACCOUNT_NUMBER'
  rate_builder.add_ship_from company_name: 'Veeqo Limited', phone_number: '01792 123456', attention_name: 'Veeqo', address_line_1: '11 Wind Street', city: 'Swansea', state: 'Wales', postal_code: 'SA1 1DA', country: 'GB', shipper_number: 'ACCOUNT_NUMBER'
  rate_builder.add_ship_to company_name: 'Google Inc.', phone_number: '0207 031 3000', address_line_1: '1 St Giles High Street', city: 'London', state: 'England', postal_code: 'WC2H 8AG', country: 'GB'
  rate_builder.add_package weight: '0.5', unit: 'KGS'
end

response.status_description
# => "Success" 
response.error_description
# => NoMethodError (undefined method `[]' for nil:NilClass)
```